### PR TITLE
rename Driver() -> WrapDriver(), improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here's a complete example:
 ```go
 func run(dsn string) {
         // install the wrapped driver
-        sql.Register("postgres-mw", sqlmw.Driver(pq.Driver{}, new(sqlInterceptor)))
+        sql.Register("postgres-mw", sqlmw.WrapDriver(pq.Driver{}, new(sqlInterceptor)))
 
         db, err := sql.Open("pq-mw", "postgres://user@localhost:5432/db")
         if err != nil {

--- a/README.md
+++ b/README.md
@@ -20,19 +20,6 @@ in a reuseable way, and more.
 Here's a complete example:
 
 ```go
-func run(dsn string) {
-        // install the wrapped driver
-        sql.Register("postgres-mw", sqlmw.WrapDriver(pq.Driver{}, new(sqlInterceptor)))
-
-        db, err := sql.Open("pq-mw", "postgres://user@localhost:5432/db")
-        if err != nil {
-                log.Fatalln(err)
-        }
-
-        // use db object as usual
-        _, _ = db.QueryContext(context.Background(), "SELECT * FROM mytable")
-}
-
 type sqlInterceptor struct {
         sqlmw.NullInterceptor
 }
@@ -44,6 +31,19 @@ func (in *sqlInterceptor) ConnQueryContext(ctx context.Context, conn driver.Quer
         log.Printf("executed sql query, query: %s, err: %s, duration: %s", query, err, time.Since(startedAt))
 
         return rows, err
+}
+
+func run(dsn string) {
+        // install the wrapped driver
+        sql.Register("postgres-mw", sqlmw.WrapDriver(pq.Driver{}, new(sqlInterceptor)))
+
+        db, err := sql.Open("pq-mw", "postgres://user@localhost:5432/db")
+        if err != nil {
+                log.Fatalln(err)
+        }
+
+        // use db object as usual
+        _, _ = db.QueryContext(context.Background(), "SELECT * FROM mytable")
 }
 ```
 

--- a/driver.go
+++ b/driver.go
@@ -14,9 +14,9 @@ var (
 	_ driver.DriverContext = wrappedDriver{}
 )
 
-// Driver wraps the passed driver and return a new SQL driver that has all of
+// WrapDriver wraps the passed driver and return a new SQL driver that has all of
 // its calls intercepted by the supplied Interceptor object.
-func Driver(driver driver.Driver, intr Interceptor) driver.Driver {
+func WrapDriver(driver driver.Driver, intr Interceptor) driver.Driver {
 	return wrappedDriver{parent: driver, intr: intr}
 }
 

--- a/driver.go
+++ b/driver.go
@@ -14,16 +14,8 @@ var (
 	_ driver.DriverContext = wrappedDriver{}
 )
 
-// WrapDriver will wrap the passed SQL driver and return a new sql driver that uses it and also logs and traces calls using the passed logger and tracer
-// The returned driver will still have to be registered with the sql package before it can be used.
-//
-
-// Driver returns the supplied driver.Driver with a new object that has all of its calls intercepted by the supplied
-// Interceptor object.
-//
-// Important note: Seeing as the context passed into the various instrumentation calls this package calls,
-// Any call without a context passed will not be intercepted. Please be sure to use the ___Context() and BeginTx()
-// function calls added in Go 1.8 instead of the older calls which do not accept a context.
+// Driver wraps the passed driver and return a new SQL driver that has all of
+// its calls intercepted by the supplied Interceptor object.
 func Driver(driver driver.Driver, intr Interceptor) driver.Driver {
 	return wrappedDriver{parent: driver, intr: intr}
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -24,7 +24,7 @@ func TestRowsClose(t *testing.T) {
 	interceptor := rowsCloseInterceptor{}
 
 	con := fakeConn{}
-	sql.Register(driverName, Driver(&fakeDriver{conn: &con}, &interceptor))
+	sql.Register(driverName, WrapDriver(&fakeDriver{conn: &con}, &interceptor))
 
 	db, err := sql.Open(driverName, "")
 	if err != nil {

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -18,7 +18,7 @@ func TestDefaultParameterConversion(t *testing.T) {
 	fakeStmt := fakeStmtWithValStore{}
 	sql.Register(
 		driverNameWithSQLmw,
-		Driver(&fakeDriver{conn: &fakeConn{stmt: &fakeStmt}}, &NullInterceptor{}),
+		WrapDriver(&fakeDriver{conn: &fakeConn{stmt: &fakeStmt}}, &NullInterceptor{}),
 	)
 
 	db, err := sql.Open(driverNameWithSQLmw, "")
@@ -125,7 +125,7 @@ func TestWrappedStmt_CheckNamedValue(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			sql.Register("fake-driver:"+name, Driver(test.fd, &fakeInterceptor{}))
+			sql.Register("fake-driver:"+name, WrapDriver(test.fd, &fakeInterceptor{}))
 			db, err := sql.Open("fake-driver:"+name, "dummy")
 			if err != nil {
 				t.Errorf("Failed to open: %v", err)
@@ -235,7 +235,7 @@ func TestWrapStmt(t *testing.T) {
 	fakeStmt := fakeStmt{}
 	sql.Register(
 		driverNameWithSQLmw,
-		Driver(&fakeDriver{conn: &fakeConn{stmt: &fakeStmt}}, &wrapStmtInterceptor{}),
+		WrapDriver(&fakeDriver{conn: &fakeConn{stmt: &fakeStmt}}, &wrapStmtInterceptor{}),
 	)
 
 	db, err := sql.Open(driverNameWithSQLmw, "")


### PR DESCRIPTION
```
        readme: in the first example, move run() function to the end

-------------------------------------------------------------------------------
        driver: rename Driver() function to WrapDriver()

        The new name is more clear.

-------------------------------------------------------------------------------
        driver: fix godoc documentation of Driver() function

        - remove inapplicable note about calls without a context, those calls are also
          intercepted
        - remove documentation for non-existing WrapDriver method
        - shorten the documentation

-------------------------------------------------------------------------------
```